### PR TITLE
Use plain rendering for the help files

### DIFF
--- a/app/controllers/ajax_help_controller.rb
+++ b/app/controllers/ajax_help_controller.rb
@@ -55,7 +55,7 @@ class AjaxHelpController < ApplicationController
     contents = File.read( help_for_language( language, resource ) )
     links = File.exists?( links_for_language( language, resource ) ) ?
       File.read( links_for_language( language, resource ) ) : ""
-    render :html => RDiscount.new(contents+links).to_html
+    render :plain => RDiscount.new(contents+links).to_html
   end
 
 end


### PR DESCRIPTION
Using :html rendering applies unwanted HTML escaping to the response